### PR TITLE
fix missing leading zeroes in some zipcodes

### DIFF
--- a/neighbor/service.py
+++ b/neighbor/service.py
@@ -31,7 +31,15 @@ class NeighborService:
         log.info(f"Getting {count} nearest {sourceType} to postal code {postalCode}")
         neighbors = self.storage.get_neighbors_by_zip(count, sourceType, postalCode, miles)
         for neighbor in neighbors:
-            neighbor.update(json.loads(neighbor["rowdata"]))
+            rowdata = json.loads(neighbor['rowdata'])
+
+            ziplen = len(rowdata['zip'])
+
+            # dirty hack to prepend lost leading zeroes
+            if ziplen == 4 or ziplen == 8:
+                rowdata['zip'] = "0" + rowdata['zip']
+
+            neighbor.update(rowdata)
             neighbor.pop("rowdata")
 
         return neighbors


### PR DESCRIPTION
This "fixes" the problem where certain zipcodes with leading zeroes (any of [these](https://en.wikipedia.org/wiki/List_of_ZIP_Code_prefixes#Starts_with_0)) are missing the leading zeroes in the JSON response.